### PR TITLE
Fix value argument's default value

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -20,7 +20,7 @@ export const position = (element, value, settings = {}) => {
   let options = settings;
   if (isObject(value)) {
     options = value;
-    value = null;
+    value = undefined;
   }
   const ctx = getContext(options);
   const caret = createCaret(element, ctx);
@@ -42,7 +42,7 @@ export const offset = (element, value, settings = {}) => {
   let options = settings;
   if (isObject(value)) {
     options = value;
-    value = null;
+    value = undefined;
   }
 
   const ctx = getContext(options);


### PR DESCRIPTION
The `getPosition` function inside `input.js` checks strictly for `undefined`. Hence assigning `null` during the value sanitization is invalid.
Also, the JSDoc for `offset` states that the values should be of types `number` or `undefined`.